### PR TITLE
Refactor certificate issuance logic and update README for clarity

### DIFF
--- a/mini-ca/README.md
+++ b/mini-ca/README.md
@@ -54,9 +54,11 @@ make init                # => docker compose --profile setup run …
 make up                  # => docker compose up -d
 
 # 3️⃣  mint a certificate whenever you need one
-docker compose run --rm cli \
-        issue blog.acme.test --san www.blog.acme.test
+docker compose run --rm cli issue blog.acme.test --san www.blog.acme.test
 ```
+--san flag is optional
+If omitted, the tool automatically sets SAN =DOMAIN.
+Use --san (or --san=…) only when you need additional names.
 
 Result inside the volume:
 

--- a/mini-ca/run/issue_cert.py
+++ b/mini-ca/run/issue_cert.py
@@ -9,20 +9,32 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from ca_core import ensure_dir, load_ca
 
 
-def issue_cert(domain: str, san: list[str],
-               ca_dir: Path, certs_dir: Path) -> None:
+def _short_label(name: str) -> str:
+    """Return the leading DNS label (foo from foo.bar.tld / *.foo.bar)."""
+    return name.lstrip("*.").split(".")[0]
 
+
+def issue_cert(
+    domain: str,
+    san: list[str],
+    ca_dir: Path,
+    certs_dir: Path,
+    full_path: bool = False,
+) -> None:
+    """Issue a leaf certificate + key and write them to *certs_dir*."""
     ca_key, ca_cert = load_ca(ca_dir)
     if not isinstance(ca_key, rsa.RSAPrivateKey):
         raise TypeError("CA key must be an RSA key for certificate signing.")
 
-    key = rsa.generate_private_key(65537, 2048)
+    # ─── build X.509 ──────────────────────────────────────────────────────
+    key  = rsa.generate_private_key(65537, 2048)
     subj = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domain)])
     sans = [x509.DNSName(domain), *[x509.DNSName(d) for d in san]]
 
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subj).issuer_name(ca_cert.subject)
+        .subject_name(subj)
+        .issuer_name(ca_cert.subject)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.utcnow())
@@ -31,8 +43,11 @@ def issue_cert(domain: str, san: list[str],
         .sign(ca_key, hashes.SHA256())
     )
 
-    out_dir = certs_dir / domain
+    # ─── output folder ────────────────────────────────────────────────────
+    folder   = domain if full_path else _short_label(domain)
+    out_dir  = certs_dir / folder
     ensure_dir(out_dir)
+
     (out_dir / f"{domain}.key").write_bytes(
         key.private_bytes(
             serialization.Encoding.PEM,
@@ -40,9 +55,7 @@ def issue_cert(domain: str, san: list[str],
             serialization.NoEncryption(),
         )
     )
-    (out_dir / f"{domain}.crt").write_bytes(
-        cert.public_bytes(serialization.Encoding.PEM)
-    )
+    (out_dir / f"{domain}.crt").write_bytes(cert.public_bytes(serialization.Encoding.PEM))
 
     typer.echo(
         f"\n✅  Certificate issued for '{domain}' → {out_dir}\n"


### PR DESCRIPTION
Enhance the certificate issuance process by improving the logic and adding options for output folder structure. Update the README to clarify usage instructions, including the optional SAN flag.