### PR TITLE
Fix README formatting and enhance entry-init.sh script

### DIFF
--- a/mini-ca/Makefile
+++ b/mini-ca/Makefile
@@ -33,7 +33,7 @@ logs:
 	$(COMPOSE) logs -f minica
 
 clean:
-	-$(COMPOSE) down --volumes --remove-orphans
+	$(COMPOSE) down --volumes --remove-orphans
 
 nuke: clean
 	@echo "🔴  NUKE: removing all artefacts for project '$(PROJECT)' …"

--- a/mini-ca/README.md
+++ b/mini-ca/README.md
@@ -1,4 +1,5 @@
 # 🔐 mini‑ca
+
 *A zero‑dependency Certificate Authority in a single Docker image*
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
@@ -6,42 +7,42 @@
 
 ---
 
-## Contents <!-- omit in toc -->
+##  Contents <!-- omit in toc -->
 
 1. [Highlights](#highlights)
 2. [Quick start](#quick-start)
 3. [Repository layout](#repository-layout)
 4. [Docker stack](#docker-stack)
-5. [Command‑line interface](#command‑line-interface)
-6. [Live domain‑watch](#live-domain‑watch)
+5. [Command‑line interface](#command-line-interface)
+6. [Live domain‑watch](#live-domain-watch)
 7. [Make targets](#make-targets)
-8. [Clean ↔ Rebuild matrix](#clean↔rebuild-matrix)
-9. [💣 `make nuke` – full reset](#make nuke--full-reset)
+8. [Clean ↔ Rebuild matrix](#clean-rebuild-matrix)
+9. [💣 `make nuke` – full reset](#make-nuke-full-reset)
 10. [Configuration](#configuration)
-11. [Best practices & CI notes](#best-practices--ci-notes)
+11. [Best practices & CI notes](#best-practices-ci-notes)
 12. [Troubleshooting](#troubleshooting)
 
 ---
 
-## Highlights
+##  Highlights
 
 | ✔︎ | Feature |
 |----|---------|
-| **One‑shot root CA** – `entry-init.sh` generates *rootCA.key + rootCA.crt* (10 yrs). |
-| **Offline image** – wheels baked at build‑time, **no outbound net** in production. |
-| **Idempotent bootstrap** – safe re‑runs; add `--force` to rotate keys. |
-| **Leaf certs on demand** – `issue <domain> [--san alt …]` drops key / cert / chain in its own dir. |
-| **Wildcard + unlimited SANs** – `*.example.dev` & friends. |
-| **Continuous watcher** – tails `/data/DOMAINS` → auto‑issues as lines appear. |
-| **Named volume** – everything under **`minica-data`** survives container churn. |
-| **Profiles** – *init* (bootstrap) · *minica* (watch) · *cli* (ad‑hoc). |
-| **Friendly Makefile** – `help • build • init • setup • up • logs • clean • nuke`. |
-| **Colourised logs** – success lines start with `✅`. |
-| **Complete wipe** – `make nuke` kills containers, volume, images **and** BuildKit cache. |
+| **One‑shot root CA** | `entry-init.sh` generates *rootCA.key + rootCA.crt* (10 yrs). |
+| **Offline image** | wheels baked at build‑time, **no outbound net** in production. |
+| **Idempotent bootstrap** | safe re‑runs; add `--force` to rotate keys. |
+| **Leaf certs on demand** | `issue <domain> [--san alt …]` drops key / cert / chain in its own dir. |
+| **Wildcard + unlimited SANs** | `*.example.dev` & friends. |
+| **Continuous watcher** | tails `/data/DOMAINS` → auto‑issues as lines appear. |
+| **Named volume** | everything under **`minica-data`** survives container churn. |
+| **Profiles** | *init* (bootstrap) · *minica* (watch) · *cli* (ad‑hoc). |
+| **Friendly Makefile** | `help • build • init • setup • up • logs • clean • nuke`. |
+| **Colourised logs** | success lines start with `✅`. |
+| **Complete wipe** | `make nuke` kills containers, volume, images **and** BuildKit cache. |
 
 ---
 
-## Quick start
+##  Quick start {#quick-start}
 
 ```bash
 git clone https://github.com/your-org/mini-ca.git
@@ -56,6 +57,7 @@ make up                  # => docker compose up -d
 # 3️⃣  mint a certificate whenever you need one
 docker compose run --rm cli issue blog.acme.test --san www.blog.acme.test
 ```
+
 --san flag is optional
 If omitted, the tool automatically sets SAN =DOMAIN.
 Use --san (or --san=…) only when you need additional names.
@@ -112,7 +114,7 @@ All services mount **`minica-data`** → `/data`.
 
 ---
 
-##  Command‑line interface
+##  Command‑line interface {#command-line-interface}
 
 ```bash
 mini_ca.py init   [--force]
@@ -133,7 +135,7 @@ docker run --rm -v minica-data:/data minica \
 
 ---
 
-##  Live domain‑watch
+##  Live domain‑watch {#live-domain-watch}
 
 1. `make up` – starts **minica** which tails `/data/DOMAINS`.
 2. Append hostnames – every line triggers `issue`.
@@ -174,7 +176,7 @@ WATCH=0 make up            # skip starting the watcher
 
 ---
 
-##  Clean↔Rebuild matrix
+##  Clean↔Rebuild matrix {#clean-rebuild-matrix}
 
 | Need | Command |
 |------|---------|
@@ -185,7 +187,7 @@ WATCH=0 make up            # skip starting the watcher
 
 ---
 
-##  make nuke – full reset
+##  make nuke – full reset {#make-nuke-full-reset}
 
 ```bash
 make nuke
@@ -218,7 +220,7 @@ Override via `docker compose build --build-arg UID=$(id -u)` or editing `docker-
 
 ---
 
-##  Best practices & CI notes
+##  Best practices & CI notes {#best-practices-ci-notes}
 
 | Tip | Why |
 |-----|-----|

--- a/mini-ca/docker/entry-init.sh
+++ b/mini-ca/docker/entry-init.sh
@@ -1,52 +1,37 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------
+#  entry‑init.sh – bootstrap the root CA inside the minica image
+#  This version has **zero** reliance on mktemp / heredocs, so it
+#  works the same whether you build the image yourself or pull it.
+# ------------------------------------------------------------------
 set -eu
 
-UID_MYCA=${UID_MYCA:-1001}
-GID_MYCA=${GID_MYCA:-1001}
-
+# ------------------------------------------------------------------
+# 1. make sure the named volume is owned by the runtime user (myca)
+# ------------------------------------------------------------------
+UID_MYCA=1001
+GID_MYCA=1001
 DATA_DIR=/data
-CA_DIR="${DATA_DIR}/rootCA"
-DOMAINS_FILE="${DATA_DIR}/DOMAINS"
 
 echo "[minica‑init] ensuring perms on ${DATA_DIR}"
-chown "${UID_MYCA}:${GID_MYCA}" "${DATA_DIR}" || true
+#  ─ chmod / chown will fail the very first time because /data is empty.
+#    That’s fine – swallow the error with `|| true`.
+chown -R "${UID_MYCA}:${GID_MYCA}" "${DATA_DIR}" 2>/dev/null || true
 
-##############################################################################
-# create a short script that will run *as myca* (no scary nested quoting)
-##############################################################################
-INIT_SCRIPT=$(mktemp)
-
-cat > "${INIT_SCRIPT}" <<'EOSH'
-#!/usr/bin/env sh
-set -eu
-
-# NOTE: the variables below are substituted *before* we switch user
-CA_DIR="${CA_DIR}"
-DOMAINS_FILE="${DOMAINS_FILE}"
-DATA_DIR="${DATA_DIR}"
-UID_MYCA="${UID_MYCA}"
-GID_MYCA="${GID_MYCA}"
-
-if [ ! -f "${CA_DIR}/rootCA.key" ] || [ ! -f "${CA_DIR}/rootCA.crt" ]; then
-  echo "[minica‑init] generating root CA …"
-  mini_ca.py init
-else
-  echo "[minica‑init] root CA already exists – skipping"
+# ------------------------------------------------------------------
+# 2. short‑circuit if a root CA already exists
+# ------------------------------------------------------------------
+if [ -f "${DATA_DIR}/rootCA/rootCA.key" ] && \
+   [ -f "${DATA_DIR}/rootCA/rootCA.crt" ]; then
+    echo "[minica‑init] root CA already exists – skipping"
+    exit 0
 fi
 
-# make sure the watcher file exists and is writable
-touch "${DOMAINS_FILE}"
+echo "[minica‑init] generating new root CA …"
 
-# final ownership sweep
-chown -R "${UID_MYCA}:${GID_MYCA}" "${DATA_DIR}"
-EOSH
-
-chmod +x "${INIT_SCRIPT}"
-
-##############################################################################
-# run it as the unprivileged myca user
-##############################################################################
-su -s /bin/sh -c "${INIT_SCRIPT}" myca
-
-rm -f "${INIT_SCRIPT}"
-echo "[minica‑init] done – volume ready"
+# ------------------------------------------------------------------
+# 3. run the actual CLI as the unprivileged user
+# ------------------------------------------------------------------
+#     · single‑quoted command → no shell‑escaping surprises
+#     · `--force` guarantees idempotence if you *do* want rotation
+exec su myca -s /bin/sh -c 'mini_ca.py init --force'

--- a/mini-ca/docker/entry-init.sh
+++ b/mini-ca/docker/entry-init.sh
@@ -1,8 +1,52 @@
 #!/usr/bin/env sh
 set -eu
 
-echo "[minica-init] fixing /data perms"
-chown -R 1001:1001 /data 2>/dev/null || true
+UID_MYCA=${UID_MYCA:-1001}
+GID_MYCA=${GID_MYCA:-1001}
 
-# run init *inside* the unprivileged account
-exec su -s /bin/sh -c "mini_ca.py init --force" myca
+DATA_DIR=/data
+CA_DIR="${DATA_DIR}/rootCA"
+DOMAINS_FILE="${DATA_DIR}/DOMAINS"
+
+echo "[minica‑init] ensuring perms on ${DATA_DIR}"
+chown "${UID_MYCA}:${GID_MYCA}" "${DATA_DIR}" || true
+
+##############################################################################
+# create a short script that will run *as myca* (no scary nested quoting)
+##############################################################################
+INIT_SCRIPT=$(mktemp)
+
+cat > "${INIT_SCRIPT}" <<'EOSH'
+#!/usr/bin/env sh
+set -eu
+
+# NOTE: the variables below are substituted *before* we switch user
+CA_DIR="${CA_DIR}"
+DOMAINS_FILE="${DOMAINS_FILE}"
+DATA_DIR="${DATA_DIR}"
+UID_MYCA="${UID_MYCA}"
+GID_MYCA="${GID_MYCA}"
+
+if [ ! -f "${CA_DIR}/rootCA.key" ] || [ ! -f "${CA_DIR}/rootCA.crt" ]; then
+  echo "[minica‑init] generating root CA …"
+  mini_ca.py init
+else
+  echo "[minica‑init] root CA already exists – skipping"
+fi
+
+# make sure the watcher file exists and is writable
+touch "${DOMAINS_FILE}"
+
+# final ownership sweep
+chown -R "${UID_MYCA}:${GID_MYCA}" "${DATA_DIR}"
+EOSH
+
+chmod +x "${INIT_SCRIPT}"
+
+##############################################################################
+# run it as the unprivileged myca user
+##############################################################################
+su -s /bin/sh -c "${INIT_SCRIPT}" myca
+
+rm -f "${INIT_SCRIPT}"
+echo "[minica‑init] done – volume ready"


### PR DESCRIPTION
Address formatting inconsistencies in the README and add missing section anchors. Refactor the entry-init.sh script to improve permission handling and streamline the root CA initialization process.